### PR TITLE
Swap values of name/reference properties for default (built-in) extruders

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ $> ./bin/extrude  https://static.sfomuseum.org/media/176/270/453/3/1762704533_jn
         "swatches": [
           {
             "colour": {
-              "name": "marekm4",
+              "name": "b6baa1",
               "hex": "#b6baa1",
-              "reference": "b6baa1"
+              "reference": "marekm4"
             },
             "closest": [
               {
@@ -136,10 +136,11 @@ $> ./bin/extrude  https://static.sfomuseum.org/media/176/270/453/3/1762704533_jn
           },
           {
             "colour": {
-              "name": "marekm4",
+              "name": "728c9a",
               "hex": "#728c9a",
-              "reference": "728c9a"
+              "reference": "marekm4"
             },
+            "closest": [
 	    ...and so on
 ```
 

--- a/common.go
+++ b/common.go
@@ -28,7 +28,7 @@ func init() {
 func NewCommonColour(ctx context.Context, uri string) (Colour, error) {
 
 	hex := "###"
-	name := "unknown"
+	name := "###"
 	ref := "unknown"
 
 	var closest []Colour

--- a/extruder/marekm4.go
+++ b/extruder/marekm4.go
@@ -30,8 +30,8 @@ func NewMarekm4Colour(ctx context.Context, str_hex string) (colours.Colour, erro
 
 	q := url.Values{}
 	q.Set("hex", str_hex)
-	q.Set("name", MAREKM4)
-	q.Set("ref", str_hex)
+	q.Set("name", str_hex)
+	q.Set("ref", MAREKM4)
 
 	u.RawQuery = q.Encode()
 

--- a/extruder/marekm4_test.go
+++ b/extruder/marekm4_test.go
@@ -16,13 +16,18 @@ func TestNewMarekm4Colour(t *testing.T) {
 		t.Fatalf("Failed to create new marekm4 colour, %v", err)
 	}
 
-	if c.Name() != MAREKM4 {
-		t.Fatalf("Invalid ref for marekm4 colour, %s", c.Name())
+	if c.Reference() != MAREKM4 {
+		t.Fatalf("Invalid ref for marekm4 colour, %s", c.Reference())
 	}
 
 	if c.Hex() != hex {
 		t.Fatalf("Invalid hex, %s (expected %s)", c.Hex(), hex)
 	}
+
+	if c.Name() != hex {
+		t.Fatalf("Invalid name, %s (expected %s)", c.Name(), hex)
+	}
+
 }
 
 func TestMarekm4Extruder(t *testing.T) {

--- a/extruder/quant.go
+++ b/extruder/quant.go
@@ -30,8 +30,8 @@ func NewQuantColour(ctx context.Context, str_hex string) (colours.Colour, error)
 
 	q := url.Values{}
 	q.Set("hex", str_hex)
-	q.Set("name", QUANT)
-	q.Set("ref", str_hex)
+	q.Set("name", str_hex)
+	q.Set("ref", QUANT)
 
 	u.RawQuery = q.Encode()
 

--- a/extruder/quant_test.go
+++ b/extruder/quant_test.go
@@ -16,13 +16,18 @@ func TestNewQuantColour(t *testing.T) {
 		t.Fatalf("Failed to create new quant colour, %v", err)
 	}
 
-	if c.Name() != QUANT {
-		t.Fatalf("Invalid ref for quant colour, %s", c.Name())
+	if c.Reference() != QUANT {
+		t.Fatalf("Invalid ref for quant colour, %s", c.Reference())
 	}
 
 	if c.Hex() != hex {
 		t.Fatalf("Invalid hex, %s (expected %s)", c.Hex(), hex)
 	}
+
+	if c.Name() != hex {
+		t.Fatalf("Invalid name, %s (expected %s)", c.Name(), hex)
+	}
+
 }
 
 func TestQuantExtruder(t *testing.T) {

--- a/extruder/vibrant.go
+++ b/extruder/vibrant.go
@@ -35,8 +35,8 @@ func NewVibrantColour(ctx context.Context, str_hex string) (colours.Colour, erro
 
 	q := url.Values{}
 	q.Set("hex", str_hex)
-	q.Set("name", VIBRANT)
-	q.Set("ref", str_hex)
+	q.Set("name", str_hex)
+	q.Set("ref", VIBRANT)
 
 	u.RawQuery = q.Encode()
 

--- a/extruder/vibrant_test.go
+++ b/extruder/vibrant_test.go
@@ -17,13 +17,18 @@ func TestNewVibrantColour(t *testing.T) {
 		t.Fatalf("Failed to create new vibrant colour, %v", err)
 	}
 
-	if c.Name() != VIBRANT {
-		t.Fatalf("Invalid ref for vibrant colour, %s", c.Name())
+	if c.Reference() != VIBRANT {
+		t.Fatalf("Invalid ref for vibrant colour, %s", c.Reference())
 	}
 
 	if c.Hex() != hex {
 		t.Fatalf("Invalid hex, %s (expected %s)", c.Hex(), hex)
 	}
+
+	if c.Name() != hex {
+		t.Fatalf("Invalid name, %s (expected %s)", c.Name(), hex)
+	}
+
 }
 
 func TestVibrantExtruder(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/sfomuseum/go-flags v0.10.0
 	github.com/sfomuseum/go-www-show v1.0.0
 	github.com/soniakeys/quant v1.0.0
-	golang.org/x/image v0.27.0
+	golang.org/x/image v0.28.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -14,7 +14,7 @@ github.com/sfomuseum/go-www-show v1.0.0 h1:Q0vRdbCz2Ulqgut85vm0kRyO7FXPbO/gay5QM
 github.com/sfomuseum/go-www-show v1.0.0/go.mod h1:P2RVABhL8JumRWLHXQ6AA8epIkBSTWAZ5LlL7zO07TE=
 github.com/soniakeys/quant v1.0.0 h1:N1um9ktjbkZVcywBVAAYpZYSHxEfJGzshHCxx/DaI0Y=
 github.com/soniakeys/quant v1.0.0/go.mod h1:HI1k023QuVbD4H8i9YdfZP2munIHU4QpjsImz6Y6zds=
-golang.org/x/image v0.27.0 h1:C8gA4oWU/tKkdCfYT6T2u4faJu3MeNS5O8UPWlPF61w=
-golang.org/x/image v0.27.0/go.mod h1:xbdrClrAUway1MUTEZDq9mz/UpRwYAkFFNUslZtcB+g=
+golang.org/x/image v0.28.0 h1:gdem5JW1OLS4FbkWgLO+7ZeFzYtL3xClb97GaUzYMFE=
+golang.org/x/image v0.28.0/go.mod h1:GUJYXtnGKEUgggyzh+Vxt+AviiCcyiwpsl8iQ8MvwGY=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,7 +25,7 @@ github.com/sfomuseum/go-www-show
 github.com/soniakeys/quant
 github.com/soniakeys/quant/internal
 github.com/soniakeys/quant/mean
-# golang.org/x/image v0.27.0
+# golang.org/x/image v0.28.0
 ## explicit; go 1.23.0
 golang.org/x/image/draw
 golang.org/x/image/math/f64


### PR DESCRIPTION
* Swap values of name/reference properties for default (built-in) extruders, so the `name` property is now the same as the `hex` property and `reference` property is the name of the extruder.
* Since this release changes default values it should be treated as NOT backwards compatible.